### PR TITLE
Prep for v1.2.1 and Chrome Web Store submission

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,13 @@
 # rolod0x security analysis
 
 Since security is paramount in web3, every effort has been made to eliminate
-any risk caused by using rolod0x.  Its design is inherently low risk since:
+any risk caused by using rolod0x.
+
+## Security design
+
+rolod0x's design is inherently low risk since:
+
+- It uses the minimum possible permissions, as documented [below](#perms).
 
 - It only operates on sites approved by the user.
 
@@ -18,6 +24,11 @@ any risk caused by using rolod0x.  Its design is inherently low risk since:
 - The data is stored locally within an isolated storage area in the
   browser reserved for the extension.
 
+- Even though the address lookup feature writes to the clipboard, it only
+  writes addresses which the user provided themself.
+
+## Risk assessment
+
 However, there are still some minor risks which need to be considered:
 
 1. There is a theoretical but extremely unlikely possibility that the
@@ -32,11 +43,26 @@ However, there are still some minor risks which need to be considered:
    and can be mitigated much more easily by virtue of the fact that the code
    is Free and Open Source and can be easily audited and rebuilt from
    source.  If this makes you nervous, you should consider that web3 wallet
-   extensions are in general a far more lucrative target for this type of attack.
+   extensions are in general a *far* more lucrative target for this type of attack.
 
 3. The browser could be compromised via a bug, which could allow attackers
    access to the extension's local storage.  Again, this risk applies to
    all browser extensions, including web3 wallet extensions.
+
+## Manifest permissions <a name="perms"></a>
+
+The following chrome API permissions are requested by the extension manifest:
+
+- `clipboardWrite`: Required to copy the selected address to the clipboard,
+  when the user completes their search of the address book.
+
+- `scripting`: Required when the user presses the search hotkey, to
+  execute the script which displays the modal dialog for searching
+  the address book.
+
+- `storage`: Required to store the user's address book and settings locally.
+
+## Feedback
 
 This is work in progress, and any suggestions for improvements are very welcome -
 please see [`CONTRIBUTING.md`](CONTRIBUTING.md).

--- a/docs/install.md
+++ b/docs/install.md
@@ -20,7 +20,7 @@ directory (see [#19][] and [#15][]).  This will greatly simplify installation.
 However for now, you can download a `.zip` file from one of three places:
 
 1. Go to [the releases page][releases], pick a recent release, and then look
-   for an asset named something like `rolod0x-v1.2.0-chrome.zip` at the Assets
+   for an asset named something like `rolod0x-v1.2.1-chrome.zip` at the Assets
    section at the bottom of the release page.
 
 2. View [the list of recent builds of the `main` branch][main].  Click

--- a/docs/publishing.org
+++ b/docs/publishing.org
@@ -1,0 +1,98 @@
+This file tracks the work required to publish rolod0x in a variety of
+places.  Being able to reuse previous work should make future
+submissions easier.
+
+* YouTube promo video
+*** voiceover script
+***** overview
+      If your phone didn't have an address book feature,
+      you'd never know who was calling you, and /making/
+      phone calls would be painful too.
+
+      So why accept anything less when browsing onchain?
+***** title page
+      rolod0x is a free privacy-preserving address book which gives you
+      a much smoother experience when browsing sites onchain.
+***** right-click demo
+      Instead of keeping track of long hexadecimal addresses, simply
+      right-click an address ... and give it a memorable label.  Now when
+      you go to any page, you can always see that label wherever the
+      page refers to that address.
+
+      This makes understanding onchain activity way easier, and it works
+      on any website and any blockchain!
+***** lookup
+      You can also quickly look up any address by pressing a hotkey, and then
+      just type part of what you're looking for.
+***** view address book
+      From the settings page you can see your whole address book in one
+      place.
+***** privacy
+      To protect your privacy, it's stored locally in your browser, so
+      it never leaves your device.
+***** edit as text
+      It's just plain text which is easy to edit, and you can
+      export and import addresses from anywhere simply with copy and paste.
+***** enable per site
+      For maximum security, rolod0x is only enabled on a limited list of
+      websites, but you can add extra sites if you want.
+***** theme and display format
+      To suit everyone's tastes, there's a dark colour theme, and you
+      can also customise the way the labels are shown on the page.
+***** FOSS
+      Finally, rolod0x is Free and Open Source software, so anyone can
+      help make it better.  So if you think of something which can be improved
+      visit the GitHub project and get involved!
+***** sign-off
+      If you like rolod0x, please spread the word!
+
+      Thanks for watching!
+*** screencast order
+***** highlight first 5
+***** renumber hardware wallets -> click Save
+***** select line -> right-click -> copy
+***** click Sites -> scroll to allow list
+*** video description
+    rolod0x is a free privacy-preserving address book which gives you a much smoother experience when browsing sites onchain.  Instead of keeping track of long hexadecimal addresses, simply right-click an address, and give it a memorable label.
+
+    Now when you go to any page, the extension automatically replaces that address wherever it appears with the label you provided.
+
+    This makes understanding onchain activity way easier, and it works on any website and any blockchain!  You can also quickly look up any address by pressing a hotkey, and then just type part of what you're looking for.
+
+    To protect your privacy, it's stored locally in your browser, so it never leaves your device without your permission.
+
+    For maximum security, rolod0x is only enabled on a limited list of websites, but you can add extra sites if you want.
+
+    rolod0x is Free and Open Source software, so anyone can help make it better.  So if you think of something which can be improved visit the GitHub project and get involved!
+* Chrome Web Store submission
+*** Store listing
+***** description
+      rolod0x is a free privacy-preserving address book which gives you a much smoother experience when browsing sites onchain.
+
+      Instead of having to keep track of long hexadecimal addresses, simply right-click an address and give it a memorable label.  Now when you go to any page, the extension automatically replaces that address wherever it appears with the label you provided.  This makes understanding onchain activity way easier, and it works on any website and any blockchain!
+
+      You can also quickly look up any address by pressing a hotkey, and then just type part of what you're looking for.
+
+      From the settings page you can see your whole address book in one place. To protect your privacy, it's stored locally in your browser, so it never leaves your device.  It's just plain text which is easy to edit, and you can export and import addresses from anywhere simply with copy and paste.
+
+      For maximum security, rolod0x is only enabled on a limited list of websites, but you can add extra sites if you want.
+
+      To suit everyone's tastes, there's a dark colour theme, and you can also customise the way the labels are shown on the page.
+
+      Finally, rolod0x is Free and Open Source software, so anyone can help make it better.  So if you think of something which can be improved visit the GitHub project and get involved!
+
+      If you like rolod0x, please spread the word!
+*** Privacy
+***** Single purpose
+rolod0x is a privacy-preserving address book extension for web3 which gives users a much smoother experience when browsing sites onchain.
+
+Instead of having to keep track of long hexadecimal addresses, users can simply right-click an address and give it a memorable label.  Now when they go to any page, the extension automatically replaces that address wherever it appears with the label they provided.  This makes understanding onchain activity way easier, and it works on any website and any blockchain.
+
+They can also quickly look up any address by pressing a hotkey, and then just type part of what they're looking for.
+***** Permission justification
+******* activeTab
+******* clipboardWrite
+******* contextMenus
+******* scripting
+******* storage
+******* Host permission

--- a/manifest.js
+++ b/manifest.js
@@ -55,9 +55,13 @@ const manifest = {
   // name: '__MSG_extensionName__',
   // description: '__MSG_extensionDescription__',
   permissions: [
-    // Needed so that the extension context menu toggle from webext-permission-toggle
-    // knows which tab it's on.
-    'activeTab',
+    // activeTab is documented as required by webext-permission-toggle,
+    // but doesn't seem to be required on Chrome with MV2 or MV3.
+    // See https://github.com/fregante/webext-permission-toggle/issues/50
+    // 'activeTab',
+    //
+    // See also https://github.com/aspiers/rolod0x/issues/216
+    // which may require activeTab in the future.
 
     'clipboardWrite',
     'contextMenus', // Also needed for webext-permission-toggle

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rolod0x",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Your free private onchain address book",
   "license": "MIT",
   "repository": {

--- a/src/pages/background/contextMenu.ts
+++ b/src/pages/background/contextMenu.ts
@@ -1,10 +1,32 @@
 const CONTEXT_MENU_ID = 'rolod0x-context-menu';
 
+function debugClickEvent(
+  message: string,
+  info: chrome.contextMenus.OnClickData,
+  tab: chrome.tabs.Tab,
+): void {
+  console.log(message);
+  console.log('Context menu OnClickData:', info);
+  console.log('Tab info:', tab || '<tab undefined>');
+}
+
 // Horrible hack to work around https://issues.chromium.org/issues/40375229 -
 // see https://stackoverflow.com/questions/7703697/how-to-retrieve-the-element-where-a-contextmenu-has-been-executed
 function handleContextMenuClick(info: chrome.contextMenus.OnClickData, tab: chrome.tabs.Tab): void {
+  if (info.menuItemId !== CONTEXT_MENU_ID) {
+    debugClickEvent('Update address book handler ignoring other context menu click', info, tab);
+    return;
+  }
+
+  if (!info.frameUrl) {
+    // This could happen if there's no activeTab permission and the extension hasn't been granted
+    // permission to the tab's site.
+    debugClickEvent("Can't send update address book message to unknown frame", info, tab);
+    return;
+  }
+
   if (info.frameUrl.startsWith('chrome-extension://')) {
-    console.log('NOT sending update address book message to chrome extension', info, tab);
+    debugClickEvent('NOT sending update address book message to chrome extension', info, tab);
     return;
   }
 

--- a/src/pages/content/contextMenu.ts
+++ b/src/pages/content/contextMenu.ts
@@ -53,8 +53,8 @@ async function updateHandler() {
 }
 
 export function initContextMenu(): void {
-  // We only have access to the element that's been clicked when the context menu is first opened.
-  // Remember it for use later.
+  // We only have access to the element that's been clicked when the
+  // context menu is first opened.  Remember it for use later.
 
   document.addEventListener(
     'contextmenu',
@@ -63,11 +63,12 @@ export function initContextMenu(): void {
       // console.debug('rolod0x: Updated last right-clicked element:', clickedEl);
     },
 
-    // useCapture - the event listener is triggered in the capturing phase, before reaching the
-    // target element:
+    // useCapture - the event listener is triggered in the capturing
+    // phase, before reaching the target element:
     true,
-    // False (the default) means that the event listener is triggered in the bubbling phase, after
-    // the event has reached the target element.
+    // False (the default) means that the event listener is triggered
+    // in the bubbling phase, after the event has reached the target
+    // element.
     //
     // FIXME: Not sure if it makes any difference which we use here.
   );
@@ -85,7 +86,8 @@ export function initContextMenu(): void {
       if (sendResponse) {
         sendResponse({ clickedElementHTML: clickedEl.innerHTML });
       }
-      // This is another way of sending the element back to the background service worker:
+      // This is another way of sending the element back to the
+      // background service worker:
       //
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       // chrome.runtime.sendMessage({


### PR DESCRIPTION
Remove `activeTab` from Chrome manifest, as it seems we don't need it after all.